### PR TITLE
Enable GPU device selection in Mediapipe tasks

### DIFF
--- a/mediapipe/gpu/gl_context.h
+++ b/mediapipe/gpu/gl_context.h
@@ -167,14 +167,15 @@ class GlContext : public std::enable_shared_from_this<GlContext> {
   //
   // If create_thread is true, the context will create a thread and run all
   // OpenGL tasks on it.
-  static StatusOrGlContext Create(std::nullptr_t nullp, bool create_thread);
+  static StatusOrGlContext Create(std::nullptr_t nullp, bool create_thread,
+                                  int gpu_device = -1);
   static StatusOrGlContext Create(const GlContext& share_context,
-                                  bool create_thread);
+                                  bool create_thread, int gpu_device = -1);
   static StatusOrGlContext Create(PlatformGlContext share_context,
-                                  bool create_thread);
+                                  bool create_thread, int gpu_device = -1);
 #if HAS_EAGL
   static StatusOrGlContext Create(EAGLSharegroup* sharegroup,
-                                  bool create_thread);
+                                  bool create_thread, int gpu_device = -1);
 #endif  // HAS_EAGL
 
   // Returns the GlContext that is current on this thread. May return nullptr.
@@ -360,6 +361,7 @@ class GlContext : public std::enable_shared_from_this<GlContext> {
   EGLConfig config_;
   EGLSurface surface_ = EGL_NO_SURFACE;
   EGLContext context_ = EGL_NO_CONTEXT;
+  int gpu_device_ = -1;
 #elif HAS_EAGL
   absl::Status CreateContext(EAGLSharegroup* sharegroup);
 

--- a/mediapipe/gpu/gl_context_eagl.cc
+++ b/mediapipe/gpu/gl_context_eagl.cc
@@ -30,22 +30,26 @@
 namespace mediapipe {
 
 GlContext::StatusOrGlContext GlContext::Create(std::nullptr_t nullp,
-                                               bool create_thread) {
-  return Create(static_cast<EAGLSharegroup*>(nil), create_thread);
+                                               bool create_thread,
+                                               int gpu_device) {
+  return Create(static_cast<EAGLSharegroup*>(nil), create_thread, gpu_device);
 }
 
 GlContext::StatusOrGlContext GlContext::Create(const GlContext& share_context,
-                                               bool create_thread) {
-  return Create(share_context.context_.sharegroup, create_thread);
+                                               bool create_thread,
+                                               int gpu_device) {
+  return Create(share_context.context_.sharegroup, create_thread, gpu_device);
 }
 
 GlContext::StatusOrGlContext GlContext::Create(EAGLContext* share_context,
-                                               bool create_thread) {
-  return Create(share_context.sharegroup, create_thread);
+                                               bool create_thread,
+                                               int gpu_device) {
+  return Create(share_context.sharegroup, create_thread, gpu_device);
 }
 
 GlContext::StatusOrGlContext GlContext::Create(EAGLSharegroup* sharegroup,
-                                               bool create_thread) {
+                                               bool create_thread,
+                                               int /*gpu_device*/) {
   std::shared_ptr<GlContext> context(new GlContext());
   MP_RETURN_IF_ERROR(context->CreateContext(sharegroup));
   MP_RETURN_IF_ERROR(context->FinishInitialization(create_thread));

--- a/mediapipe/gpu/gl_context_egl.cc
+++ b/mediapipe/gpu/gl_context_egl.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <utility>
+#include <vector>
 
 #include "absl/log/absl_check.h"
 #include "absl/log/absl_log.h"
@@ -22,6 +23,7 @@
 #include "mediapipe/framework/port/ret_check.h"
 #include "mediapipe/framework/port/status.h"
 #include "mediapipe/framework/port/status_builder.h"
+#include "mediapipe/gpu/egl_base.h"
 #include "mediapipe/gpu/gl_context.h"
 #include "mediapipe/gpu/gl_context_internal.h"
 
@@ -88,26 +90,59 @@ static absl::StatusOr<EGLDisplay> GetInitializedDefaultEglDisplay() {
   return display;
 }
 
-static absl::StatusOr<EGLDisplay> GetInitializedEglDisplay() {
-  auto status_or_display = GetInitializedDefaultEglDisplay();
-  return status_or_display;
+static absl::StatusOr<EGLDisplay> GetInitializedEglDisplay(int device) {
+  if (device < 0) {
+    return GetInitializedDefaultEglDisplay();
+  }
+  auto eglQueryDevicesEXT =
+      reinterpret_cast<PFNEGLQUERYDEVICESEXTPROC>(
+          eglGetProcAddress("eglQueryDevicesEXT"));
+  auto eglGetPlatformDisplayEXT =
+      reinterpret_cast<PFNEGLGETPLATFORMDISPLAYEXTPROC>(
+          eglGetProcAddress("eglGetPlatformDisplayEXT"));
+  RET_CHECK(eglQueryDevicesEXT && eglGetPlatformDisplayEXT)
+      << "EGL device enumeration not supported";
+  EGLint num_devices = 0;
+  eglQueryDevicesEXT(0, nullptr, &num_devices);
+  RET_CHECK_GT(num_devices, device)
+      << "GPU device index out of range";
+  std::vector<EGLDeviceEXT> devices(num_devices);
+  eglQueryDevicesEXT(num_devices, devices.data(), &num_devices);
+  EGLDisplay display =
+      eglGetPlatformDisplayEXT(EGL_PLATFORM_DEVICE_EXT,
+                               devices[device], nullptr);
+  RET_CHECK(display != EGL_NO_DISPLAY)
+      << "eglGetPlatformDisplayEXT() returned error " << std::showbase
+      << std::hex << eglGetError();
+
+  EGLint major = 0;
+  EGLint minor = 0;
+  EGLBoolean egl_initialized = eglInitialize(display, &major, &minor);
+  RET_CHECK(egl_initialized) << "Unable to initialize EGL";
+  ABSL_LOG(INFO) << "Successfully initialized EGL. Major : " << major
+                 << " Minor: " << minor;
+  return display;
 }
 
 }  // namespace
 
 GlContext::StatusOrGlContext GlContext::Create(std::nullptr_t nullp,
-                                               bool create_thread) {
-  return Create(EGL_NO_CONTEXT, create_thread);
+                                               bool create_thread,
+                                               int gpu_device) {
+  return Create(EGL_NO_CONTEXT, create_thread, gpu_device);
 }
 
 GlContext::StatusOrGlContext GlContext::Create(const GlContext& share_context,
-                                               bool create_thread) {
-  return Create(share_context.context_, create_thread);
+                                               bool create_thread,
+                                               int gpu_device) {
+  return Create(share_context.context_, create_thread, gpu_device);
 }
 
 GlContext::StatusOrGlContext GlContext::Create(EGLContext share_context,
-                                               bool create_thread) {
+                                               bool create_thread,
+                                               int gpu_device) {
   std::shared_ptr<GlContext> context(new GlContext());
+  context->gpu_device_ = gpu_device;
   MP_RETURN_IF_ERROR(context->CreateContext(share_context));
   MP_RETURN_IF_ERROR(context->FinishInitialization(create_thread));
   return std::move(context);
@@ -177,7 +212,7 @@ absl::Status GlContext::CreateContextInternal(EGLContext share_context,
 }
 
 absl::Status GlContext::CreateContext(EGLContext share_context) {
-  MP_ASSIGN_OR_RETURN(display_, GetInitializedEglDisplay());
+  MP_ASSIGN_OR_RETURN(display_, GetInitializedEglDisplay(gpu_device_));
 
   auto status = CreateContextInternal(share_context, 3);
   if (!status.ok()) {

--- a/mediapipe/gpu/gl_context_nsgl.cc
+++ b/mediapipe/gpu/gl_context_nsgl.cc
@@ -27,17 +27,20 @@
 namespace mediapipe {
 
 GlContext::StatusOrGlContext GlContext::Create(std::nullptr_t nullp,
-                                               bool create_thread) {
-  return Create(static_cast<NSOpenGLContext*>(nil), create_thread);
+                                               bool create_thread,
+                                               int gpu_device) {
+  return Create(static_cast<NSOpenGLContext*>(nil), create_thread, gpu_device);
 }
 
 GlContext::StatusOrGlContext GlContext::Create(const GlContext& share_context,
-                                               bool create_thread) {
-  return Create(share_context.context_, create_thread);
+                                               bool create_thread,
+                                               int gpu_device) {
+  return Create(share_context.context_, create_thread, gpu_device);
 }
 
 GlContext::StatusOrGlContext GlContext::Create(NSOpenGLContext* share_context,
-                                               bool create_thread) {
+                                               bool create_thread,
+                                               int /*gpu_device*/) {
   std::shared_ptr<GlContext> context(new GlContext());
   MP_RETURN_IF_ERROR(context->CreateContext(share_context));
   MP_RETURN_IF_ERROR(context->FinishInitialization(create_thread));

--- a/mediapipe/gpu/gl_context_webgl.cc
+++ b/mediapipe/gpu/gl_context_webgl.cc
@@ -31,17 +31,21 @@ namespace mediapipe {
 
 // TODO: Handle webGL "context lost" and "context restored" events.
 GlContext::StatusOrGlContext GlContext::Create(std::nullptr_t nullp,
-                                               bool create_thread) {
-  return Create(static_cast<EMSCRIPTEN_WEBGL_CONTEXT_HANDLE>(0), create_thread);
+                                               bool create_thread,
+                                               int gpu_device) {
+  return Create(static_cast<EMSCRIPTEN_WEBGL_CONTEXT_HANDLE>(0), create_thread,
+                gpu_device);
 }
 
 GlContext::StatusOrGlContext GlContext::Create(const GlContext& share_context,
-                                               bool create_thread) {
-  return Create(share_context.context_, create_thread);
+                                               bool create_thread,
+                                               int gpu_device) {
+  return Create(share_context.context_, create_thread, gpu_device);
 }
 
 GlContext::StatusOrGlContext GlContext::Create(
-    EMSCRIPTEN_WEBGL_CONTEXT_HANDLE share_context, bool create_thread) {
+    EMSCRIPTEN_WEBGL_CONTEXT_HANDLE share_context, bool create_thread,
+    int /*gpu_device*/) {
   std::shared_ptr<GlContext> context(new GlContext());
   MP_RETURN_IF_ERROR(context->CreateContext(share_context));
   MP_RETURN_IF_ERROR(context->FinishInitialization(create_thread));

--- a/mediapipe/gpu/gpu_shared_data_internal.cc
+++ b/mediapipe/gpu/gpu_shared_data_internal.cc
@@ -93,16 +93,18 @@ static const std::string& SharedContextKey() {
   return *kSharedContextKey;
 }
 
-GpuResources::StatusOrGpuResources GpuResources::Create() {
-  return Create(kPlatformGlContextNone);
+GpuResources::StatusOrGpuResources GpuResources::Create(int gpu_device) {
+  return Create(kPlatformGlContextNone, /*gpu_buffer_pool_options=*/nullptr,
+                gpu_device);
 }
 
 GpuResources::StatusOrGpuResources GpuResources::Create(
     PlatformGlContext external_context,
-    const MultiPoolOptions* gpu_buffer_pool_options) {
+    const MultiPoolOptions* gpu_buffer_pool_options, int gpu_device) {
   MP_ASSIGN_OR_RETURN(
       std::shared_ptr<GlContext> context,
-      GlContext::Create(external_context, kGlContextUseDedicatedThread));
+      GlContext::Create(external_context, kGlContextUseDedicatedThread,
+                        gpu_device));
   std::shared_ptr<GpuResources> gpu_resources(
       new GpuResources(std::move(context), gpu_buffer_pool_options));
   return gpu_resources;
@@ -110,9 +112,9 @@ GpuResources::StatusOrGpuResources GpuResources::Create(
 
 GpuResources::StatusOrGpuResources GpuResources::Create(
     const GpuResources& gpu_resources,
-    const MultiPoolOptions* gpu_buffer_pool_options) {
+    const MultiPoolOptions* gpu_buffer_pool_options, int gpu_device) {
   return Create(gpu_resources.gl_context()->native_context(),
-                gpu_buffer_pool_options);
+                gpu_buffer_pool_options, gpu_device);
 }
 
 GpuResources::GpuResources(std::shared_ptr<GlContext> gl_context,

--- a/mediapipe/gpu/gpu_shared_data_internal.h
+++ b/mediapipe/gpu/gpu_shared_data_internal.h
@@ -50,18 +50,20 @@ class GpuResources {
  public:
   using StatusOrGpuResources = absl::StatusOr<std::shared_ptr<GpuResources>>;
 
-  static StatusOrGpuResources Create();
+  static StatusOrGpuResources Create(int gpu_device = -1);
   // Optional gpu_buffer_pool_options argument allows to configure the
   // GpuBufferMultiPool instance.
   static StatusOrGpuResources Create(
       PlatformGlContext external_context,
-      const MultiPoolOptions* gpu_buffer_pool_options = nullptr);
+      const MultiPoolOptions* gpu_buffer_pool_options = nullptr,
+      int gpu_device = -1);
 
   // Creates a GpuResources instance that is shared with the GL context provided
   // by the gpu_resources argument.
   static StatusOrGpuResources Create(
       const GpuResources& gpu_resources,
-      const MultiPoolOptions* gpu_buffer_pool_options = nullptr);
+      const MultiPoolOptions* gpu_buffer_pool_options = nullptr,
+      int gpu_device = -1);
 
   // The destructor must be defined in the implementation file so that on iOS
   // the correct ARC release calls are generated.

--- a/mediapipe/tasks/python/core/base_options.py
+++ b/mediapipe/tasks/python/core/base_options.py
@@ -49,6 +49,9 @@ class BaseOptions:
     model_asset_buffer: The model asset file contents as bytes.
     delegate: Acceleration to use. Supported values are GPU and CPU. GPU support
       is currently limited to Ubuntu platforms.
+    gpu_device: Optional GPU device ordinal. When using the GPU delegate this
+      specifies which CUDA device (e.g. ``0`` for ``cuda:0``) should be used.
+      If unset, the first available device is used.
   """
 
   class Delegate(enum.IntEnum):
@@ -58,6 +61,7 @@ class BaseOptions:
   model_asset_path: Optional[str] = None
   model_asset_buffer: Optional[bytes] = None
   delegate: Optional[Delegate] = None
+  gpu_device: Optional[Any] = None
 
   @doc_controls.do_not_generate_docs
   def to_pb2(self) -> _BaseOptionsProto:

--- a/mediapipe/tasks/python/core/pybind/task_runner.cc
+++ b/mediapipe/tasks/python/core/pybind/task_runner.cc
@@ -65,7 +65,8 @@ mode) or not (synchronous mode).)doc");
   task_runner.def_static(
       "create",
       [](CalculatorGraphConfig graph_config,
-         std::optional<py::function> packets_callback) {
+         std::optional<py::function> packets_callback,
+         int gpu_device) {
         PacketsCallback callback = nullptr;
         if (packets_callback.has_value()) {
           callback =
@@ -80,7 +81,7 @@ mode) or not (synchronous mode).)doc");
         }
 
 #if !MEDIAPIPE_DISABLE_GPU
-        auto gpu_resources_ = mediapipe::GpuResources::Create();
+        auto gpu_resources_ = mediapipe::GpuResources::Create(gpu_device);
         if (!gpu_resources_.ok()) {
           ABSL_LOG(INFO) << "GPU suport is not available: "
                          << gpu_resources_.status();
@@ -113,13 +114,15 @@ Args:
   graph_config: A MediaPipe task graph config protobuf object.
   packets_callback: A user-defined packets callback function that takes a list
      of output packets as the input argument.
+  gpu_device: The GPU device ordinal to run on. -1 uses the default device.
 
 Raises:
   RuntimeError: Any of the following:
     a) The graph config proto is invalid.
     b) The underlying medipaipe graph fails to initialize and start.
 )doc",
-      py::arg("graph_config"), py::arg("packets_callback") = py::none());
+      py::arg("graph_config"), py::arg("packets_callback") = py::none(),
+      py::arg("gpu_device") = -1);
 
   task_runner.def(
       "process",

--- a/mediapipe/tasks/python/vision/core/base_vision_task_api.py
+++ b/mediapipe/tasks/python/vision/core/base_vision_task_api.py
@@ -43,6 +43,7 @@ class BaseVisionTaskApi(object):
       packet_callback: Optional[
           Callable[[Mapping[str, packet_module.Packet]], None]
       ] = None,
+      gpu_device: int = -1,
   ) -> None:
     """Initializes the `BaseVisionTaskApi` object.
 
@@ -67,7 +68,7 @@ class BaseVisionTaskApi(object):
           'The vision task is in image or video mode, a user-defined result '
           'callback should not be provided.'
       )
-    self._runner = _TaskRunner.create(graph_config, packet_callback)
+    self._runner = _TaskRunner.create(graph_config, packet_callback, gpu_device)
     self._running_mode = running_mode
 
   def _process_image_data(

--- a/mediapipe/tasks/python/vision/hand_landmarker.py
+++ b/mediapipe/tasks/python/vision/hand_landmarker.py
@@ -361,6 +361,16 @@ class HandLandmarker(base_vision_task_api.BaseVisionTaskApi):
         ],
         task_options=options,
     )
+    gpu_device_id = -1
+    if options.base_options and options.base_options.gpu_device is not None:
+        device = options.base_options.gpu_device
+        try:
+            if isinstance(device, str):
+                gpu_device_id = int(device.split(":")[1]) if ":" in device else int(device)
+            else:
+                gpu_device_id = int(device)
+        except ValueError:
+            gpu_device_id = -1
     return cls(
         task_info.generate_graph_config(
             enable_flow_limiting=options.running_mode
@@ -368,6 +378,7 @@ class HandLandmarker(base_vision_task_api.BaseVisionTaskApi):
         ),
         options.running_mode,
         packets_callback if options.result_callback else None,
+        gpu_device_id,
     )
 
   def detect(


### PR DESCRIPTION
## Summary
- allow specifying GPU device id from Python BaseOptions
- plumb GPU id through task runner and GpuResources
- create EGL context for requested GPU device

## Testing
- `pytest` *(fails: 72 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_68b1975245b08331b0f1b6450c598d59